### PR TITLE
Fix for first localization call

### DIFF
--- a/src/LocalizationStartup.cs
+++ b/src/LocalizationStartup.cs
@@ -73,12 +73,8 @@ namespace Insya.Localization
 
                 Resource.GetXmlResource(path, applicationName);
             }
-            else
-            {
-                return HttpContext.Current.Application[applicationName + id].ToString();
-            }
-
-            return id;
+            
+	    return HttpContext.Current.Application[applicationName + id].ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
First localization call always failed because of a bug in
LocalizationStartup.cs
